### PR TITLE
Use URI fragment as query parameters

### DIFF
--- a/simple_auth/lib/src/providers/dropbox.dart
+++ b/simple_auth/lib/src/providers/dropbox.dart
@@ -53,6 +53,15 @@ class DropboxAuthenticator extends OAuthAuthenticator {
   String uid;
   bool checkUrl(Uri url) {
     try {
+      /*
+       * If dropbox uses fragments instead of query parameters then swap convert
+       * them to parameters so it is easier to parse. This also allows us to use
+       * parameters if they don't use fragments.
+       */
+      if (url.hasFragment && !url.hasQuery) {
+        url = url.replace(query: url.fragment);
+      }
+      
       if (url?.host != redirectUri.host) return false;
       if (url?.query?.isEmpty ?? true) return false;
       if (!url.queryParameters.containsKey(authCodeKey)) return false;


### PR DESCRIPTION
Dropbox appears to use fragments in the URL instead of query parameters to send access_token, token_type, etc..

So for example - dropbox will use this for sending data:
com.example.appname:/redirect#access_token=GkzaizgrXXpW4wLNnptxzHJNGkzaizgrXXpW4wLNnptxzHJN&token_type=bearer&uid=1112223&account_id=dbid%3GkzaizgrXXpW4wLNnptxzHJN-AaadrkjrfuyP1M